### PR TITLE
Add checks for integer and floating-point sizes and ranges.

### DIFF
--- a/Game/Networking/Packets.hpp
+++ b/Game/Networking/Packets.hpp
@@ -2,6 +2,7 @@
 
 #include "BinarySerialization.hpp"
 #include "..\Definitions\TimeAndNetwork.hpp"
+#include "..\Utilities\AssertTypeSizes.hpp"
 
 #include <cstdint>
 #include <tuple>

--- a/Game/Utilities/AssertTypeSizes.hpp
+++ b/Game/Utilities/AssertTypeSizes.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <cstdint>
+
+
+//We don't actually want to enforce most these, it's just a check, because it's important to know these sizes.
+static_assert(sizeof(char) == 1, "Non standard-compliant architecture. Size of char should be 1 unit.");
+#pragma warning( suppress : 4309 )
+static_assert(static_cast<unsigned char>(256) != 256, "Size of char is more than 8 bits. Strange.");
+static_assert(sizeof(int) >= 4, "Size of int is less than 4 units.");
+static_assert(sizeof(long) >= 4, "Size of long is less than 4 units.");
+static_assert(sizeof(uint8_t) == 1, "Size of uint8_t isn't 1 unit.");
+static_assert(sizeof(uint16_t) == 2, "Size of uint16_t isn't 2 units.");
+static_assert(sizeof(uint32_t) == 4, "Size of uint32_t isn't 4 units.");
+static_assert(sizeof(uint64_t) == 8, "Size of uint64_t isn't 8 units.");

--- a/Game/Utilities/AssertTypeSizes.hpp
+++ b/Game/Utilities/AssertTypeSizes.hpp
@@ -1,15 +1,17 @@
 #pragma once
 
 #include <cstdint>
+#include <climits>
 
 
 //We don't actually want to enforce most these, it's just a check, because it's important to know these sizes.
-static_assert(sizeof(char) == 1, "Non standard-compliant architecture. Size of char should be 1 unit.");
-#pragma warning( suppress : 4309 )
-static_assert(static_cast<unsigned char>(256) != 256, "Size of char is more than 8 bits. Strange.");
-static_assert(sizeof(int) >= 4, "Size of int is less than 4 units.");
-static_assert(sizeof(long) >= 4, "Size of long is less than 4 units.");
-static_assert(sizeof(uint8_t) == 1, "Size of uint8_t isn't 1 unit.");
-static_assert(sizeof(uint16_t) == 2, "Size of uint16_t isn't 2 units.");
-static_assert(sizeof(uint32_t) == 4, "Size of uint32_t isn't 4 units.");
-static_assert(sizeof(uint64_t) == 8, "Size of uint64_t isn't 8 units.");
+static_assert(sizeof(char) == 1, "sizeof(char) != 1, non standard compliant architecture.");
+static_assert(CHAR_BIT == 8, "CHAR_BIT != 8");
+static_assert(sizeof(int) >= 4, "sizeof(int) < 4");
+static_assert(sizeof(long) >= 4, "sizeof(long) < 4");
+static_assert(sizeof(float) == 4, "sizeof(float) != 4, non standard compliant floating-point implementation.");
+static_assert(sizeof(double) == 8, "sizeof(double) != 8, non standard compliant floating-point implementation.");
+static_assert(sizeof(uint8_t) == 1, "sizeof(uint8_t) != 1");
+static_assert(sizeof(uint16_t) == 2, "sizeof(uint16_t) != 2");
+static_assert(sizeof(uint32_t) == 4, "sizeof(uint32_t) != 4");
+static_assert(sizeof(uint64_t) == 8, "sizeof(uint64_t) != 8");

--- a/Game/Utilities/Utilities.vcxproj
+++ b/Game/Utilities/Utilities.vcxproj
@@ -123,6 +123,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="AssertTypeSizes.hpp" />
     <ClInclude Include="Logger.hpp" />
     <ClInclude Include="StaticLinkedList.hpp" />
   </ItemGroup>

--- a/Game/Utilities/Utilities.vcxproj.filters
+++ b/Game/Utilities/Utilities.vcxproj.filters
@@ -21,6 +21,9 @@
     <ClInclude Include="Logger.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="AssertTypeSizes.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="StaticLinkedList.cpp">


### PR DESCRIPTION
As the title says.
The C++ standard does not specify most of these, but it's important for networking.
I mean in theory. I believe that non conforming architectures are extremely rare (if not non extistent) in the PC world, but still. Just in case.