### PR TITLE
Blender export script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ and with specialized data structures optimized for memory locality, it will hope
 * Microsoft Visual Studio Community 2017 Version 15.8.2
 * Microsoft .NET Framework Version 4.7.03056
 * Unity 2017.3.1f1
+* Blender 2.79b
 ## Minimal tested development environment
 * Microsoft Visual Studio Community 2017 Version 15.7.3
 * Microsoft .NET Framework Version 4.7.03056
 * Unity 2017.3.1f1
+* Blender 2.79b

--- a/Tools/README.md
+++ b/Tools/README.md
@@ -1,5 +1,5 @@
 # Tools
-Tools for working with the game data database.
+Tools for working with the game data database, and other utility scripts.
 The most important files are the following ones:
 - sqlite3_Win32.exe  
   The SQLite3 executable.
@@ -12,3 +12,5 @@ The most important files are the following ones:
   Calls recreate_empty_db.bat then fills the tables with dummy data for testing.
 - db_command_line.bat  
   Opens a command line for the database.
+- export_shape.py
+  A Blender export script, for our custom 2D shape format.

--- a/Tools/export_shape.py
+++ b/Tools/export_shape.py
@@ -1,0 +1,73 @@
+import bpy
+
+
+def write_some_data(context, filepath, use_some_setting):
+    print("running write_some_data...")
+    f = open(filepath, 'w', encoding='utf-8')
+    f.write("Hello World %s" % use_some_setting)
+    f.close()
+
+    return {'FINISHED'}
+
+
+# ExportHelper is a helper class, defines filename and
+# invoke() function which calls the file selector.
+from bpy_extras.io_utils import ExportHelper
+from bpy.props import StringProperty, BoolProperty, EnumProperty
+from bpy.types import Operator
+
+
+class ExportSomeData(Operator, ExportHelper):
+    """This appears in the tooltip of the operator and in the generated docs"""
+    bl_idname = "export_test.some_data"  # important since its how bpy.ops.import_test.some_data is constructed
+    bl_label = "Export Some Data"
+
+    # ExportHelper mixin class uses this
+    filename_ext = ".txt"
+
+    filter_glob = StringProperty(
+            default="*.txt",
+            options={'HIDDEN'},
+            maxlen=255,  # Max internal buffer length, longer would be clamped.
+            )
+
+    # List of operator properties, the attributes will be assigned
+    # to the class instance from the operator settings before calling.
+    use_setting = BoolProperty(
+            name="Example Boolean",
+            description="Example Tooltip",
+            default=True,
+            )
+
+    type = EnumProperty(
+            name="Example Enum",
+            description="Choose between two items",
+            items=(('OPT_A', "First Option", "Description one"),
+                   ('OPT_B', "Second Option", "Description two")),
+            default='OPT_A',
+            )
+
+    def execute(self, context):
+        return write_some_data(context, self.filepath, self.use_setting)
+
+
+# Only needed if you want to add into a dynamic menu
+def menu_func_export(self, context):
+    self.layout.operator(ExportSomeData.bl_idname, text="Text Export Operator")
+
+
+def register():
+    bpy.utils.register_class(ExportSomeData)
+    bpy.types.INFO_MT_file_export.append(menu_func_export)
+
+
+def unregister():
+    bpy.utils.unregister_class(ExportSomeData)
+    bpy.types.INFO_MT_file_export.remove(menu_func_export)
+
+
+if __name__ == "__main__":
+    register()
+
+    # test call
+    bpy.ops.export_test.some_data('INVOKE_DEFAULT')

--- a/Tools/export_shape.py
+++ b/Tools/export_shape.py
@@ -1,10 +1,10 @@
 import bpy
 
 
-def write_some_data(context, filepath, use_some_setting):
-    print("running write_some_data...")
+def export_shape(context, filepath):
+    print("running export_shape...")
     f = open(filepath, 'w', encoding='utf-8')
-    f.write("Hello World %s" % use_some_setting)
+    f.write("Hello World")
     f.close()
 
     return {'FINISHED'}
@@ -17,52 +17,36 @@ from bpy.props import StringProperty, BoolProperty, EnumProperty
 from bpy.types import Operator
 
 
-class ExportSomeData(Operator, ExportHelper):
-    """This appears in the tooltip of the operator and in the generated docs"""
-    bl_idname = "export_test.some_data"  # important since its how bpy.ops.import_test.some_data is constructed
-    bl_label = "Export Some Data"
+class ShapeExporter(Operator, ExportHelper):
+    """Export the active object as a Comet Shape file"""
+    bl_idname = "export_mesh.shape"  # important since its how bpy.ops.import_mesh.shape is constructed
+    bl_label = "Export Shape"
 
     # ExportHelper mixin class uses this
-    filename_ext = ".txt"
+    filename_ext = ".shp"
 
     filter_glob = StringProperty(
-            default="*.txt",
+            default="*.shp",
             options={'HIDDEN'},
             maxlen=255,  # Max internal buffer length, longer would be clamped.
             )
 
-    # List of operator properties, the attributes will be assigned
-    # to the class instance from the operator settings before calling.
-    use_setting = BoolProperty(
-            name="Example Boolean",
-            description="Example Tooltip",
-            default=True,
-            )
-
-    type = EnumProperty(
-            name="Example Enum",
-            description="Choose between two items",
-            items=(('OPT_A', "First Option", "Description one"),
-                   ('OPT_B', "Second Option", "Description two")),
-            default='OPT_A',
-            )
-
     def execute(self, context):
-        return write_some_data(context, self.filepath, self.use_setting)
+        return export_shape(context, self.filepath)
 
 
 # Only needed if you want to add into a dynamic menu
 def menu_func_export(self, context):
-    self.layout.operator(ExportSomeData.bl_idname, text="Text Export Operator")
+    self.layout.operator(ShapeExporter.bl_idname, text="Shape (.shp)")
 
 
 def register():
-    bpy.utils.register_class(ExportSomeData)
+    bpy.utils.register_class(ShapeExporter)
     bpy.types.INFO_MT_file_export.append(menu_func_export)
 
 
 def unregister():
-    bpy.utils.unregister_class(ExportSomeData)
+    bpy.utils.unregister_class(ShapeExporter)
     bpy.types.INFO_MT_file_export.remove(menu_func_export)
 
 
@@ -70,4 +54,4 @@ if __name__ == "__main__":
     register()
 
     # test call
-    bpy.ops.export_test.some_data('INVOKE_DEFAULT')
+    bpy.ops.export_mesh.shape('INVOKE_DEFAULT')

--- a/Tools/export_shape.py
+++ b/Tools/export_shape.py
@@ -11,15 +11,26 @@ def export_shape(context, filepath):
     mesh = object.data
     with open(filepath, 'w', encoding='utf-8') as f:
         f.write("{} {}\n".format(len(mesh.vertices), len(mesh.polygons)))
+        #Print vertices.
         for v in mesh.vertices:
             assert len(v.co) == 3, "Coordinate is not XYZ."
             f.write("{} {}\n".format(v.co[0], v.co[1])) #Z coordinate is implicitly 0.
+        #Print UV coordinates.
         if mesh.uv_layers.active: #If there is a UV mapping specified.
             uvs = {mesh.loops[l].vertex_index: mesh.uv_layers.active.data[l].uv for p in mesh.polygons for l in p.loop_indices}
             for v in mesh.vertices:
                 f.write("{} {}\n".format(uvs[v.index][0], uvs[v.index][1]))
         else: #If there is no UV mapping specified.
-            pass
+            x_coordinates = [v.co[0] for v in mesh.vertices]
+            y_coordinates = [v.co[1] for v in mesh.vertices]
+            min_x = min(x_coordinates)
+            max_x = max(x_coordinates)
+            min_y = min(y_coordinates)
+            max_y = max(y_coordinates)
+            max_diff = max_x - min_x if max_x - min_x > max_y - min_y else max_y - min_y
+            for v in mesh.vertices:
+                f.write("{} {}\n".format((v.co[0] - min_x) / max_diff, (v.co[1] - min_y) / max_diff))
+        #Print triangles.
         for p in mesh.polygons:
             assert len(p.vertices) == 3, "Mesh is not triangulated."
             f.write("{} {} {}\n".format(p.vertices[0], p.vertices[1], p.vertices[2]))

--- a/Tools/export_shape.py
+++ b/Tools/export_shape.py
@@ -1,7 +1,7 @@
 import bpy
 
 
-def export_shape(context, filepath):
+def export_shape(context, filepath, recreate_uv):
     print("running export_shape...")
     object = context.active_object
     bpy.ops.object.mode_set(mode='EDIT')
@@ -16,11 +16,11 @@ def export_shape(context, filepath):
             assert len(v.co) == 3, "Coordinate is not XYZ."
             f.write("{} {}\n".format(v.co[0], v.co[1])) #Z coordinate is implicitly 0.
         #Print UV coordinates.
-        if mesh.uv_layers.active: #If there is a UV mapping specified.
+        if mesh.uv_layers.active and not recreate_uv: #If there is a UV mapping specified which we want to keep.
             uvs = {mesh.loops[l].vertex_index: mesh.uv_layers.active.data[l].uv for p in mesh.polygons for l in p.loop_indices}
             for v in mesh.vertices:
                 f.write("{} {}\n".format(uvs[v.index][0], uvs[v.index][1]))
-        else: #If there is no UV mapping specified.
+        else: #If there is no UV mapping specified, or we want to recreate it.
             x_coordinates = [v.co[0] for v in mesh.vertices]
             y_coordinates = [v.co[1] for v in mesh.vertices]
             min_x = min(x_coordinates)
@@ -59,8 +59,16 @@ class ShapeExporter(Operator, ExportHelper):
             maxlen=255,  # Max internal buffer length, longer would be clamped.
             )
 
+    # List of operator properties, the attributes will be assigned
+    # to the class instance from the operator settings before calling.
+    recreate_uv = BoolProperty(
+                    name="Recreate UV",
+                    description="Automatically recreate the UV mapping, even if one already exists",
+                    default=True,
+                  )
+
     def execute(self, context):
-        return export_shape(context, self.filepath)
+        return export_shape(context, self.filepath, self.recreate_uv)
 
 
 # Only needed if you want to add into a dynamic menu


### PR DESCRIPTION
An export script that possibly transforms a Blender model, then exports it into our custom 2D shape format. Also updates 2 `README`s.
The format is the following (for now):
ASCII text encoding, the first line might consist of 1 or 2 space separated numbers.
If it's exactly 1 number, then that's a double, and it denotes the radius of a circle, which is the only shape described by the file. The way to describe the `UV` coordinates in this case is yet to be determined.
If there are exactly 2 numbers, `N` and `M`, then they are integers, `N` denoting the number of vertices, `M` denoting the number of faces. Every polygon of `N` vertices has exactly `N - 2` faces, but this way, with `M` explicitly specified, we can also describe sets of disjoint triangles, and also immediately differentiate this from the former case (1 vs. 2 numbers). After this `2 * N + M` rows follow. All of them consist of space separated numbers. The first `N` rows being the `XY` coordinates of the vertices, the next `N` rows the `UV` coordinates, and the last `M` rows the 3 vertex indices defining the face.