### PR TITLE
Detect buffer overflow

### DIFF
--- a/CometServer/Networking/Protocol.cpp
+++ b/CometServer/Networking/Protocol.cpp
@@ -125,6 +125,7 @@ namespace net
 		auto[count, entities, payloads] = importstrategy.ImportServerState();
 		for (size_t i = 0; i < count; i++)
 		{
+			//TODO: Why write the buffer for entities we don't send anyway?
 			packet.payload = &(payloads[i]);
 			size_t bytes_written = packet.IO<Write>(buffer); //TODO: Handle overflow.
 			if (registry.Contains(entities[i]))

--- a/CometServer/Networking/Protocol.cpp
+++ b/CometServer/Networking/Protocol.cpp
@@ -1,5 +1,8 @@
 #include "Protocol.hpp"
 
+#include <cassert>
+
+
 namespace net
 {
 
@@ -128,6 +131,7 @@ namespace net
 			//TODO: Why write the buffer for entities we don't send anyway?
 			packet.payload = &(payloads[i]);
 			size_t bytes_written = packet.IO<Write>(buffer); //TODO: Handle overflow.
+			assert(bytes_written < def::max_packet_size && "Buffer overflow error.");
 			if (registry.Contains(entities[i]))
 			{
 				socket.Send(registry.GetAddress(entities[i]), buffer, static_cast<int>(bytes_written)); //TODO: Maybe tracelog sent bytes.


### PR DESCRIPTION
With the current packet size of 1000 it is fairly easy to make to socket's input buffer overflow (it only takes about 40 entities), which combined with the use of raw arrays can and does cause memory corruption. Originally it used to overwrite and unset the `running` flag, causing the server to terminate without properly stopping the background thread. Now, after some changes it seems to overwrite something else, causing a strange infinite loop bug (with not sending any data to the client anymore).

This pull request adds an explicit check to see if we have overran the buffer, but this is of course not a sufficient solution.