### PR TITLE
Explicit column names in SQL inserts

### DIFF
--- a/Tools/load_dummy_data.sql
+++ b/Tools/load_dummy_data.sql
@@ -1,18 +1,22 @@
 BEGIN TRANSACTION;
 
-INSERT INTO Users VALUES(0, 'placeholder');
-INSERT INTO Users VALUES(1, 'placeholder');
-INSERT INTO Users VALUES(2, 'placeholder');
-INSERT INTO Users VALUES(3, 'placeholder');
-INSERT INTO Users VALUES(4, 'placeholder');
+INSERT INTO Users
+(UserID,	PasswordHash) VALUES
+(0,			'placeholder'),
+(1,			'placeholder'),
+(2,			'placeholder'),
+(3,			'placeholder'),
+(4,			'placeholder');
 
 --Fill table Shapes.
 
-INSERT INTO Entities VALUES(0, 1, 2, 0, 'inertial', 'dynamic', 'visible', 'collidable', 0, 0, 0);
-INSERT INTO Entities VALUES(1, 2, 1, 1, 'inertial', 'dynamic', 'visible', 'collidable', 10, 0, 0);
-INSERT INTO Entities VALUES(2, 3, 2, 0, 'inertial', 'dynamic', 'visible', 'collidable', 10, 10, 0);
-INSERT INTO Entities VALUES(3, 4, 0, 0, 'inertial', 'dynamic', 'visible', 'collidable', 0, 10, 0);
-INSERT INTO Entities VALUES(4, 1, 0, 0, 'anti_inertial', 'dynamic', 'visible', 'collidable', -10, 0, 0);
-INSERT INTO Entities VALUES(5, 1, 3, 0, 'para_inertial', 'dynamic', 'visible', 'collidable', 0, -10, 0);
+INSERT INTO Entities
+(EntityID,	OwnerID,	ShapeID,	TextureID,	Engine,			Dynamics,	Visibility,	Collidability,	PositionX,	PositionY,	Orientation) VALUES
+(0,			1,			2,			0,			'inertial',		'dynamic',	'visible',	'collidable',	0,			0,			0),
+(1,			2,			1,			1,			'inertial',		'dynamic',	'visible',	'collidable',	10,			0,			0),
+(2,			3,			2,			0,			'inertial',		'dynamic',	'visible',	'collidable',	10,			10,			0),
+(3,			4,			0,			0,			'inertial',		'dynamic',	'visible',	'collidable',	0,			10,			0),
+(4,			1,			0,			0,			'anti_inertial','dynamic',	'visible',	'collidable',	-10,		0,			0),
+(5,			1,			3,			0,			'para_inertial','dynamic',	'visible',	'collidable',	0,			-10,		0);
 
 COMMIT;


### PR DESCRIPTION
As the titles says, specify column names explicitly in human-written in SQL, making it more readable. I also aligned the values with the column names, it looks decent with a tab size of 4. For some reason git diff seems to use 8-width tabs, so in this pull request, it looks wrong.