### PR TITLE
Implement 'into Circle' collision detection algorithms

### DIFF
--- a/CometClient/Assets/Resources/FishEye.shader
+++ b/CometClient/Assets/Resources/FishEye.shader
@@ -37,7 +37,7 @@
 			{
 				v2f o;
 				o.vertex = UnityObjectToClipPos(v.vertex);
-				o.vertex.xy /= sqrt(length(o.vertex.xy) * 10);
+				o.vertex.xy /= max(sqrt(length(o.vertex.xy) * 10), 0.000001);
 				o.uv = TRANSFORM_TEX(v.uv, _MainTex);
 				return o;
 			}

--- a/CometClient/Assets/main.unity
+++ b/CometClient/Assets/main.unity
@@ -192,7 +192,7 @@ Prefab:
     m_Modifications:
     - target: {fileID: 400000, guid: ba7885c2653056540a3538de4ade19bf, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.00005
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: ba7885c2653056540a3538de4ade19bf, type: 3}
       propertyPath: m_LocalPosition.y

--- a/CometServer/Entities/AbstractCollisionShape.cpp
+++ b/CometServer/Entities/AbstractCollisionShape.cpp
@@ -13,4 +13,14 @@ namespace entity
 	{
 	}
 
+	const geo::degree& AbstractCollisionShape::GetOrientation() const
+	{
+		return orientation;
+	}
+
+	const geo::vector_2d& AbstractCollisionShape::GetPosition() const
+	{
+		return position;
+	}
+
 }

--- a/CometServer/Entities/AbstractCollisionShape.hpp
+++ b/CometServer/Entities/AbstractCollisionShape.hpp
@@ -24,6 +24,8 @@ namespace entity
 		virtual bool CollideInto(geo::EmptyFrame, geo::EmptyFrame, Circle&) = 0;
 		virtual const geo::EmptyFrame& GetBoundingBox() = 0;
 		virtual std::string GetName() = 0; //Useful for debugging.
+		const geo::degree& GetOrientation() const;
+		const geo::vector_2d& GetPosition() const;
 
 	protected:
 

--- a/CometServer/Entities/AbstractTriangulatedPoly.cpp
+++ b/CometServer/Entities/AbstractTriangulatedPoly.cpp
@@ -1,4 +1,5 @@
 #include "AbstractTriangulatedPoly.hpp"
+#include "Circle.hpp"
 
 
 namespace entity 
@@ -73,8 +74,13 @@ namespace entity
 
 	bool AbstractTriangulatedPoly::CollideInto(geo::EmptyFrame myframe, geo::EmptyFrame otherframe, Circle& that)
 	{
+		for (size_t i = 0; i < vertices.size(); ++i)
+		{
+			geo::point_2d point = geo::add(geo::point_2d_rotated(vertices.at(i), orientation), position);
+			//TODO: Handle frames.
+			if (/*geo::is_inside(myframe, point) && */geo::length(geo::sub(point, that.GetPosition())) <= that.GetRadius()) return true;
+		}
 		return false;
-		//TODO: implement this.
 	}
 
 }

--- a/CometServer/Entities/Circle.cpp
+++ b/CometServer/Entities/Circle.cpp
@@ -26,6 +26,7 @@ namespace entity
 	
 	bool Circle::CollideInto(geo::EmptyFrame myframe, geo::EmptyFrame otherframe, Circle& that)
 	{
+		//TODO: Handle frames.
 		return geo::length(geo::sub(this->position, that.position)) <= this->radius + that.radius;
 	}
 	

--- a/CometServer/Entities/Circle.cpp
+++ b/CometServer/Entities/Circle.cpp
@@ -26,8 +26,7 @@ namespace entity
 	
 	bool Circle::CollideInto(geo::EmptyFrame myframe, geo::EmptyFrame otherframe, Circle& that)
 	{
-		return false;
-		//TODO: implement this.
+		return geo::length(geo::sub(this->position, that.position)) <= this->radius + that.radius;
 	}
 	
 	const geo::EmptyFrame& Circle::GetBoundingBox()

--- a/CometServer/Entities/Circle.cpp
+++ b/CometServer/Entities/Circle.cpp
@@ -40,4 +40,9 @@ namespace entity
 		return "Circle";
 	}
 
+	const geo::real& Circle::GetRadius() const
+	{
+		return radius;
+	}
+
 }

--- a/CometServer/Entities/Circle.hpp
+++ b/CometServer/Entities/Circle.hpp
@@ -21,6 +21,7 @@ namespace entity
 		virtual bool CollideInto(geo::EmptyFrame, geo::EmptyFrame, Circle&) override;
 		virtual const geo::EmptyFrame& GetBoundingBox() override;
 		virtual std::string GetName() override;
+		const geo::real& GetRadius() const;
 
 		const geo::real radius;
 

--- a/CometServer/Entities/Entities.vcxproj
+++ b/CometServer/Entities/Entities.vcxproj
@@ -114,7 +114,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>..\Utilities\sqlite3_$(Platform).lib;..\Geometry\$(Platform)\$(Configuration)\Geometry.obj;..\Utilities\$(Platform)\$(Configuration)\StaticLinkedList.obj;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>..\Utilities\sqlite3_$(Platform).lib;..\Geometry\$(Platform)\$(Configuration)\Geometry.obj;..\Utilities\$(Platform)\$(Configuration)\StaticLinkedList.obj;..\Utilities\$(Platform)\$(Configuration)\Logger.obj;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug - no collision|Win32'">
@@ -128,7 +128,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>..\Utilities\sqlite3_$(Platform).lib;..\Geometry\$(Platform)\$(Configuration)\Geometry.obj;..\Utilities\$(Platform)\$(Configuration)\StaticLinkedList.obj;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>..\Utilities\sqlite3_$(Platform).lib;..\Geometry\$(Platform)\$(Configuration)\Geometry.obj;..\Utilities\$(Platform)\$(Configuration)\StaticLinkedList.obj;..\Utilities\$(Platform)\$(Configuration)\Logger.obj;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -141,7 +141,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>..\Utilities\sqlite3_$(Platform).lib;..\Geometry\$(Platform)\$(Configuration)\Geometry.obj;..\Utilities\$(Platform)\$(Configuration)\StaticLinkedList.obj;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>..\Utilities\sqlite3_$(Platform).lib;..\Geometry\$(Platform)\$(Configuration)\Geometry.obj;..\Utilities\$(Platform)\$(Configuration)\StaticLinkedList.obj;..\Utilities\$(Platform)\$(Configuration)\Logger.obj;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug - no collision|x64'">
@@ -155,7 +155,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>..\Utilities\sqlite3_$(Platform).lib;..\Geometry\$(Platform)\$(Configuration)\Geometry.obj;..\Utilities\$(Platform)\$(Configuration)\StaticLinkedList.obj;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>..\Utilities\sqlite3_$(Platform).lib;..\Geometry\$(Platform)\$(Configuration)\Geometry.obj;..\Utilities\$(Platform)\$(Configuration)\StaticLinkedList.obj;..\Utilities\$(Platform)\$(Configuration)\Logger.obj;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -172,7 +172,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>..\Utilities\sqlite3_$(Platform).lib;..\Geometry\$(Platform)\$(Configuration)\Geometry.obj;..\Utilities\$(Platform)\$(Configuration)\StaticLinkedList.obj;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>..\Utilities\sqlite3_$(Platform).lib;..\Geometry\$(Platform)\$(Configuration)\Geometry.obj;..\Utilities\$(Platform)\$(Configuration)\StaticLinkedList.obj;..\Utilities\$(Platform)\$(Configuration)\Logger.obj;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -189,7 +189,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>..\Utilities\sqlite3_$(Platform).lib;..\Geometry\$(Platform)\$(Configuration)\Geometry.obj;..\Utilities\$(Platform)\$(Configuration)\StaticLinkedList.obj;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>..\Utilities\sqlite3_$(Platform).lib;..\Geometry\$(Platform)\$(Configuration)\Geometry.obj;..\Utilities\$(Platform)\$(Configuration)\StaticLinkedList.obj;..\Utilities\$(Platform)\$(Configuration)\Logger.obj;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/CometServer/Entities/Universe.cpp
+++ b/CometServer/Entities/Universe.cpp
@@ -2,6 +2,7 @@
 #include "TriangulatedPolyNaiveRotation.hpp"
 #include "Circle.hpp"
 #include "..\Utilities\sqlite3.h"
+#include "..\Utilities\Logger.hpp"
 
 #include <sstream>
 
@@ -256,7 +257,10 @@ namespace entity
 					AbstractCollisionShape& shape1 = *collision_shape_registry.at(p_entity1->id);
 					AbstractCollisionShape& shape2 = *collision_shape_registry.at(p_entity2->id);
 					//TODO: Crop bounding boxes to the current partition.
-					shape1.InviteForCollision(shape1.GetBoundingBox(), shape2.GetBoundingBox(), shape2);
+					if (shape1.InviteForCollision(shape1.GetBoundingBox(), shape2.GetBoundingBox(), shape2))
+					{
+						util::Log(util::trace, "Entity " + std::to_string(p_entity2->id) + " collided into entity " + std::to_string(p_entity1->id) + ".");
+					}
 					#endif
 				}
 			}

--- a/Tools/load_dummy_data.sql
+++ b/Tools/load_dummy_data.sql
@@ -18,6 +18,7 @@ INSERT INTO Entities
 (3,			4,			0,			0,			'inertial',		'dynamic',	'visible',	'collidable',	0,			10,			0),
 (4,			1,			0,			0,			'anti_inertial','dynamic',	'visible',	'collidable',	-10,		0,			0),
 (5,			1,			3,			0,			'para_inertial','dynamic',	'visible',	'collidable',	0,			-10,		0),
-(6,			1,			5,			0,			'inertial',		'dynamic',	'visible',	'collidable',	20,			0,			0);
+(6,			1,			5,			0,			'inertial',		'dynamic',	'visible',	'collidable',	20,			0,			0),
+(7,			2,			5,			0,			'inertial',		'dynamic',	'visible',	'collidable',	25,			0,			0);
 
 COMMIT;


### PR DESCRIPTION
This PR adds actual collision detection algorithms for circle into circle and polygon into circle type of collisions, another circle shaped entity in the dummy data and logging, so it can be tested, and a bugfix in the fish eye shader avoiding division by zero errors, which is necessary for circles, as they have a center (0,0) vertex.
Not that the collision detection algorithms are not complete in the sense that they do not currently used the `EmtpyFrame`s passed as parameters (the `GetBoundingBox` methods are yet to be implemented).