### PR TITLE
Collision editor nits

### DIFF
--- a/CollisionTestEditor/Drawing.cs
+++ b/CollisionTestEditor/Drawing.cs
@@ -11,8 +11,6 @@ namespace CollisionTestEditor
 	{
 		private static Color color1 = Color.Red;
 		private static Color color2 = Color.Blue;
-		private static Color color1transcluent = Color.FromArgb(128, color1);
-		private static Color color2transcluent = Color.FromArgb(128, color2);
 
 		private static void DrawShape(Graphics g, ViewTransformation vt, Shape shape, Color color)
 		{

--- a/CollisionTestEditor/Drawing.cs
+++ b/CollisionTestEditor/Drawing.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Drawing;
 
 namespace CollisionTestEditor
 {

--- a/CollisionTestEditor/Program.cs
+++ b/CollisionTestEditor/Program.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace CollisionTestEditor


### PR DESCRIPTION
Address the review of #65, namely remove unused variables, plus while at it, remove unused `using`s too.