### PR TITLE
Fix signed-unsigned mismatch in 32-bit mode

### DIFF
--- a/CometServer/Entities/AbstractTriangulatedPoly.cpp
+++ b/CometServer/Entities/AbstractTriangulatedPoly.cpp
@@ -30,19 +30,19 @@ namespace entity
 	bool AbstractTriangulatedPoly::CollideInto(geo::EmptyFrame myframe, geo::EmptyFrame otherframe, AbstractTriangulatedPoly& other)
 	{
 		int arr_counter = 0;
-		for (int i = 0; i < vertices.size(); ++i)
+		for (size_t i = 0; i < vertices.size(); ++i)
 		{
 			if (vertices[i].transformed(orientation, position).is_inside(myframe) &&
 				vertices[i].transformed(orientation, position).is_inside(otherframe))
 			{
-				arr[arr_counter] = i;
+				arr[arr_counter] = static_cast<int>(i);
 				arr_counter++;
 			}
 		}
 		arr[arr_counter] = -1; //TODO: Add checks for overindexing.
 		arr_counter++;
 		int other_start = arr_counter;
-		for(int i = 0; i < other.triangles.size() / 3; ++i)
+		for(size_t i = 0; i < other.triangles.size() / 3; ++i)
 		{
 			//TODO: By Unity convention, vertices are enumerated in a clockwise winding order.
 			//Maybe this extra information could be used to speed up the collision check.
@@ -54,7 +54,7 @@ namespace entity
 				point_b.is_inside(otherframe) ||
 				point_c.is_inside(otherframe))
 			{
-				arr[arr_counter] = i;
+				arr[arr_counter] = static_cast<int>(i);
 				arr_counter++;
 			}
 		}

--- a/CometServer/Entities/Circle.cpp
+++ b/CometServer/Entities/Circle.cpp
@@ -24,7 +24,7 @@ namespace entity
 		//TODO: Investigate if circle collision checks need frames at all or not.
 		//Probably not, because a circle should only be in 1 collision partition at once, since it doesn't have multiple vertices.
 		//TODO: Remove friend class declaration in AbstractTriangulatedPoly, add public getters instead.
-		for (int i = 0; i < that.triangles.size() / 3; ++i)
+		for (size_t i = 0; i < that.triangles.size() / 3; ++i)
 		{
 			//TODO: By Unity convention, vertices are enumerated in a clockwise winding order.
 			//Maybe this extra information could be used to speed up the collision check.


### PR DESCRIPTION
For whatever reason, some of these exceptions are only reported in 32-bit mode:
https://developercommunity.visualstudio.com/content/problem/335285/warning-c4018-does-not-work-when-the-sizes-of-type.html
They doesn't seem to be very dangerous, but it's better to be on the safe side.