### PR TITLE
Fix spawn asteroid texture

### DIFF
--- a/CometServer/Definitions/Gameplay.hpp
+++ b/CometServer/Definitions/Gameplay.hpp
@@ -7,4 +7,7 @@ namespace def
 	//Universe configuration constants
 	static constexpr int expected_entity_count_fluctuation = 1000;
 
+	//Collision behavior type definitions
+	using behavior_parameter = int;
+
 }

--- a/CometServer/Entities/Universe.cpp
+++ b/CometServer/Entities/Universe.cpp
@@ -2,7 +2,6 @@
 #include "TriangulatedPolyNaiveRotation.hpp"
 #include "Circle.hpp"
 #include "..\Utilities\Logger.hpp"
-#include "..\Definitions\Gameplay.hpp"
 
 #include <sstream>
 #include <cassert>
@@ -82,7 +81,7 @@ namespace entity
 		sqlite3_exec //TODO: Add error handling.
 		(
 			db_connection,
-			"SELECT ShapeID, Condition, Action, Parameter1, Parameter2 FROM CollisionBehaviors;",
+			"SELECT ShapeID, Condition, Action, Parameter1, Parameter2, Parameter3 FROM CollisionBehaviors;",
 			[](void* void_universe, int, char** argv, char**) //TODO: This belongs in Utilities.
 			{
 				Universe* universe = static_cast<Universe*>(void_universe);
@@ -92,9 +91,10 @@ namespace entity
 				else if (std::strcmp("on_collision_give", argv[1]) == 0) condition = CollisionBehavior::Condition::on_collision_give;
 				CollisionBehavior::Action action;
 				if (std::strcmp("explode", argv[2]) == 0) action = CollisionBehavior::Action::explode;
-				int parameter1 = std::atoi(argv[3]);
-				int parameter2 = std::atoi(argv[4]);
-				universe->collision_behavior_registry.emplace(shape_id, CollisionBehavior{ condition, action, parameter1, parameter2 });
+				def::behavior_parameter parameter1 = std::atoi(argv[3]);
+				def::behavior_parameter parameter2 = std::atoi(argv[4]);
+				def::behavior_parameter parameter3 = std::atoi(argv[5]);
+				universe->collision_behavior_registry.emplace(shape_id, CollisionBehavior{ condition, action, parameter1, parameter2, parameter3 });
 				return 0;
 			},
 			static_cast<void*>(this),
@@ -320,7 +320,7 @@ namespace entity
 									{
 										QueueEntitySpawn(entity_registry.at(p_entity1->id).owner,
 											collision_behavior.parameter2,
-											entity_registry.at(p_entity1->id).texture,
+											collision_behavior.parameter3,
 											inertial,
 											dynamic,
 											visible,

--- a/CometServer/Entities/Universe.hpp
+++ b/CometServer/Entities/Universe.hpp
@@ -7,6 +7,7 @@
 #include "..\Utilities\sqlite3.h"
 #include "..\Utilities\StaticLinkedList.hpp"
 #include "..\Definitions\TimeAndNetwork.hpp"
+#include "..\Definitions\Gameplay.hpp"
 
 #include <map>
 #include <unordered_map>
@@ -61,8 +62,9 @@ namespace entity
 		{
 			enum class Condition { on_collision_take, on_collision_give } condition;
 			enum class Action { explode } action;
-			int parameter1;
-			int parameter2;
+			def::behavior_parameter parameter1;
+			def::behavior_parameter parameter2;
+			def::behavior_parameter parameter3;
 		};
 
 		CollisionBehavior& GetCollisionBehavior(def::entity_id); //TODO: entity_id and shape_id should be incompatible types.

--- a/Tools/load_dummy_data.sql
+++ b/Tools/load_dummy_data.sql
@@ -11,10 +11,10 @@ INSERT INTO Users
 --Fill table Shapes.
 
 INSERT INTO CollisionBehaviors
-(ShapeID,	Condition,				Action,		Parameter1,	Parameter2) VALUES
-(8,			'on_collision_take',	'explode',	0,			-1),
-(7,			'on_collision_take',	'explode',	4,			8),
-(6,			'on_collision_take',	'explode',	4,			7);
+(ShapeID,	Condition,				Action,		Parameter1,	Parameter2, Parameter3) VALUES
+(8,			'on_collision_take',	'explode',	0,			-1,			-1),
+(7,			'on_collision_take',	'explode',	4,			8,			7),
+(6,			'on_collision_take',	'explode',	4,			7,			6);
 
 INSERT INTO Entities
 (EntityID,	OwnerID,	ShapeID,	TextureID,	Engine,				Dynamics,	Visibility,	Collidability,	PositionX,	PositionY,	Orientation) VALUES

--- a/Tools/recreate_empty_db.sql
+++ b/Tools/recreate_empty_db.sql
@@ -28,7 +28,8 @@ CREATE TABLE CollisionBehaviors
 	Condition TEXT,
 	Action TEXT,
 	Parameter1 INTEGER,
-	Parameter2 INTEGER
+	Parameter2 INTEGER,
+	Parameter3 INTEGER
 );
 
 CREATE TABLE Entities


### PR DESCRIPTION
Before this fix, smaller asteroids spawned with their parent's texture, not with the one matching their own actual shape.