### PR TITLE
Increase default entity acceleration, fix weapon cooldown mechanism

### DIFF
--- a/CometServer/Entities/EntityHandle.hpp
+++ b/CometServer/Entities/EntityHandle.hpp
@@ -26,7 +26,7 @@ namespace entity
 			StaticEntity* se_pointer;
 			DynamicEntity* de_pointer;
 		};
-		def::time weapon_cooldown = def::zero_seconds;
+		def::time weapon_last_fired = def::zero_seconds;
 	};
 
 }

--- a/CometServer/Entities/Universe.cpp
+++ b/CometServer/Entities/Universe.cpp
@@ -499,7 +499,7 @@ namespace entity
 			dynamic_entity.velocity = velocity;
 			dynamic_entity.max_speed = 10;
 			dynamic_entity.inertial_velocity = { 0, 0 };
-			dynamic_entity.acceleration = { 0, 5 };
+			dynamic_entity.acceleration = { 0, 20 };
 			dynamic_entity.inertial_acceleration = { 0, 0 };
 			dynamic_entity.friction = 0;
 			auto index = dynamic_entities[visibility][collidability].InsertAtFirstGap(dynamic_entity);

--- a/CometServer/Entities/Universe.cpp
+++ b/CometServer/Entities/Universe.cpp
@@ -238,12 +238,11 @@ namespace entity
 
 	void Universe::EntityFireWithCooldown(def::time duration, DynamicEntity& entity)
 	{
-		if (entity_registry[entity.id].weapon_cooldown <= def::zero_seconds)
+		if (simulation_time > entity_registry[entity.id].weapon_last_fired + def::default_weapon_cooldown)
 		{
 			EntityFire(duration, entity);
-			entity_registry[entity.id].weapon_cooldown = def::default_weapon_cooldown;
+			entity_registry[entity.id].weapon_last_fired = simulation_time;
 		}
-		entity_registry[entity.id].weapon_cooldown -= duration;
 	}
 
 	void Universe::EntityWarp(def::time duration, DynamicEntity& entity)
@@ -269,6 +268,8 @@ namespace entity
 				}
 			}
 		}
+
+		simulation_time += duration;
 	}
 
 	void Universe::TestCollisions()

--- a/CometServer/Entities/Universe.hpp
+++ b/CometServer/Entities/Universe.hpp
@@ -71,6 +71,7 @@ namespace entity
 
 	private:
 
+		def::time simulation_time = def::zero_seconds;
 		def::entity_id max_used_entity_id = 0; //TODO: Factor this into an EntityRegistry class.
 		std::unordered_map<def::entity_id, EntityHandle> entity_registry; //TODO: Compare the speed of map and unordered map wherever possible.
 		std::unordered_map<def::shape_id, EntityShape> shape_registry;


### PR DESCRIPTION
The first one is pretty straightforward, playtesting is a lot easier with a more agile ship.

As for the cooldown, there was a bug, where the cooldown only decreased **while** the player was pushing the fire button. The new mechanism maintains a  `simulation_time` variable instead. This approach has 2 problems:
- errors accumulating in floating point addition
- errors getting bigger as we are closing to max safe integer
That being said, `double` precision is still huge, this should not cause any problems, even in a thousand years. I think.

The alternative approach of basing this calculation on frames instead of time would only work under ideal circumstances, because in theory frames might be arbitrarily delayed, this is the whole reason the `Update` function has a `duration` argument to begin with.

A last note on the name of this branch: originally I wanted to make bullet dynamics more realistic, but that made aiming a lot harder, so I undid that change. Filed #85, so we won't forget about it.