### PR TITLE
Better entity management in client

### DIFF
--- a/CometClient/Assets/Code/ContentManagement/EntityFactory.cs
+++ b/CometClient/Assets/Code/ContentManagement/EntityFactory.cs
@@ -1,13 +1,20 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 
 
 public class EntityFactory
 {
 
-	public GameObject Create(net.ShapeDescription shapeDescription)
+	public static GameObject Create(net.ShapeDescription shapeDescription)
 	{
-		return null;
+		GameObject entity = new GameObject("Entity#" + shapeDescription.entity_id);
+		entity.AddComponent<MeshFilter>();
+		entity.AddComponent<MeshRenderer>();
+		entity.GetComponent<MeshFilter>().mesh = MeshFactory.Create(shapeDescription.vertex_count, shapeDescription.triangle_count,
+			shapeDescription.vertices, shapeDescription.uvs, shapeDescription.triangles);
+		//TODO: Some kind of default material should be used here, so the fisheye could be turned off if desired.
+		entity.GetComponent<MeshRenderer>().material = new Material(Resources.Load<Shader>("Fisheye"));
+		entity.GetComponent<MeshRenderer>().material.mainTexture = TextureManager.GetTexture(shapeDescription.texture_id);
+		return entity;
 	}
+
 }

--- a/CometClient/Assets/Code/ContentManagement/EntityFactory.cs
+++ b/CometClient/Assets/Code/ContentManagement/EntityFactory.cs
@@ -3,8 +3,14 @@
 
 public class EntityFactory
 {
+	private TextureManager textureManager;
 
-	public static GameObject Create(net.ShapeDescription shapeDescription)
+	public EntityFactory()
+	{
+		textureManager = new TextureManager();
+	}
+
+	public GameObject Create(net.ShapeDescription shapeDescription)
 	{
 		GameObject entity = new GameObject("Entity#" + shapeDescription.entity_id);
 		entity.AddComponent<MeshFilter>();
@@ -13,7 +19,7 @@ public class EntityFactory
 			shapeDescription.vertices, shapeDescription.uvs, shapeDescription.triangles);
 		//TODO: Some kind of default material should be used here, so the fisheye could be turned off if desired.
 		entity.GetComponent<MeshRenderer>().material = new Material(Resources.Load<Shader>("Fisheye"));
-		entity.GetComponent<MeshRenderer>().material.mainTexture = TextureManager.GetTexture(shapeDescription.texture_id);
+		entity.GetComponent<MeshRenderer>().material.mainTexture = textureManager.GetTexture(shapeDescription.texture_id);
 		return entity;
 	}
 

--- a/CometClient/Assets/Code/ContentManagement/EntityFactory.cs
+++ b/CometClient/Assets/Code/ContentManagement/EntityFactory.cs
@@ -14,10 +14,10 @@ public class EntityFactory
 	{
 		GameObject entity = new GameObject("Entity#" + shapeDescription.entity_id);
 		entity.AddComponent<MeshFilter>();
-		entity.AddComponent<MeshRenderer>();
 		entity.GetComponent<MeshFilter>().mesh = MeshFactory.Create(shapeDescription.vertex_count, shapeDescription.triangle_count,
 			shapeDescription.vertices, shapeDescription.uvs, shapeDescription.triangles);
 		//TODO: Some kind of default material should be used here, so the fisheye could be turned off if desired.
+		entity.AddComponent<MeshRenderer>();
 		entity.GetComponent<MeshRenderer>().material = new Material(Resources.Load<Shader>("Fisheye"))
 		{
 			mainTexture = textureManager.GetTexture(shapeDescription.texture_id)

--- a/CometClient/Assets/Code/ContentManagement/EntityFactory.cs
+++ b/CometClient/Assets/Code/ContentManagement/EntityFactory.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+
+public class EntityFactory
+{
+
+	public GameObject Create(net.ShapeDescription shapeDescription)
+	{
+		return null;
+	}
+}

--- a/CometClient/Assets/Code/ContentManagement/EntityFactory.cs
+++ b/CometClient/Assets/Code/ContentManagement/EntityFactory.cs
@@ -20,6 +20,7 @@ public class EntityFactory
 		//TODO: Some kind of default material should be used here, so the fisheye could be turned off if desired.
 		entity.GetComponent<MeshRenderer>().material = new Material(Resources.Load<Shader>("Fisheye"));
 		entity.GetComponent<MeshRenderer>().material.mainTexture = textureManager.GetTexture(shapeDescription.texture_id);
+		entity.AddComponent<entity.EntityController>();
 		return entity;
 	}
 

--- a/CometClient/Assets/Code/ContentManagement/EntityFactory.cs
+++ b/CometClient/Assets/Code/ContentManagement/EntityFactory.cs
@@ -18,8 +18,10 @@ public class EntityFactory
 		entity.GetComponent<MeshFilter>().mesh = MeshFactory.Create(shapeDescription.vertex_count, shapeDescription.triangle_count,
 			shapeDescription.vertices, shapeDescription.uvs, shapeDescription.triangles);
 		//TODO: Some kind of default material should be used here, so the fisheye could be turned off if desired.
-		entity.GetComponent<MeshRenderer>().material = new Material(Resources.Load<Shader>("Fisheye"));
-		entity.GetComponent<MeshRenderer>().material.mainTexture = textureManager.GetTexture(shapeDescription.texture_id);
+		entity.GetComponent<MeshRenderer>().material = new Material(Resources.Load<Shader>("Fisheye"))
+		{
+			mainTexture = textureManager.GetTexture(shapeDescription.texture_id)
+		};
 		entity.AddComponent<entity.EntityController>();
 		return entity;
 	}

--- a/CometClient/Assets/Code/ContentManagement/EntityFactory.cs.meta
+++ b/CometClient/Assets/Code/ContentManagement/EntityFactory.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: e6ffa76c4167d3b41a64c674e68a9fe4
+timeCreated: 1572705826
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CometClient/Assets/Code/ContentManagement/TextureManager.cs
+++ b/CometClient/Assets/Code/ContentManagement/TextureManager.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 
 public class TextureManager
 {
+
 	private static Dictionary<UInt32, Texture> textures = new Dictionary<UInt32, Texture>();
 
 	private const UInt32 placeholderTextureId = 0;
@@ -54,4 +55,5 @@ public class TextureManager
 		if (textures.ContainsKey(texture_id)) return textures[texture_id];
 		else return textures[placeholderTextureId];
 	}
+
 }

--- a/CometClient/Assets/Code/ContentManagement/TextureManager.cs
+++ b/CometClient/Assets/Code/ContentManagement/TextureManager.cs
@@ -18,7 +18,7 @@ public class TextureManager
 	private const string placeholderTexturePath = "EntityTextures/placeholder";
 
 
-	static TextureManager()
+	public TextureManager()
 	{
 		textures.Add(placeholderTextureId, Resources.Load<Texture>(placeholderTexturePath));
 
@@ -34,7 +34,7 @@ public class TextureManager
 		if (!textures.ContainsKey(placeholderTextureId)) Debug.Log("Placeholder texture not loaded.");
 	}
 
-	private static void LoadTextureFromFile(string path)
+	private void LoadTextureFromFile(string path)
 	{
 		try
 		{
@@ -50,7 +50,7 @@ public class TextureManager
 		}
 	}
 
-	public static Texture GetTexture(UInt32 texture_id)
+	public Texture GetTexture(UInt32 texture_id)
 	{
 		if (textures.ContainsKey(texture_id)) return textures[texture_id];
 		else return textures[placeholderTextureId];

--- a/CometClient/Assets/Code/ContentManagement/TextureManager.cs
+++ b/CometClient/Assets/Code/ContentManagement/TextureManager.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 public class TextureManager
 {
-	private Dictionary<UInt32, Texture> textures = new Dictionary<UInt32, Texture>();
+	private static Dictionary<UInt32, Texture> textures = new Dictionary<UInt32, Texture>();
 
 	private const UInt32 placeholderTextureId = 0;
 
@@ -16,23 +16,8 @@ public class TextureManager
 	//This path is relative to Resources.
 	private const string placeholderTexturePath = "EntityTextures/placeholder";
 
-	private void LoadTextureFromFile(string path)
-	{
-		try
-		{
-			string filename = Path.GetFileName(path);
-			UInt32 id = Convert.ToUInt32(filename.Split('-')[0]);
-			Texture2D texture = new Texture2D(2, 2);
-			texture.LoadImage(File.ReadAllBytes(path));
-			textures.Add(id, texture);
-		}
-		catch (Exception)
-		{
-			Debug.Log("Loading textures, " + path + " skipped.");
-		}
-	}
 
-	public TextureManager()
+	static TextureManager()
 	{
 		textures.Add(placeholderTextureId, Resources.Load<Texture>(placeholderTexturePath));
 
@@ -48,7 +33,23 @@ public class TextureManager
 		if (!textures.ContainsKey(placeholderTextureId)) Debug.Log("Placeholder texture not loaded.");
 	}
 
-	public Texture GetTexture(UInt32 texture_id)
+	private static void LoadTextureFromFile(string path)
+	{
+		try
+		{
+			string filename = Path.GetFileName(path);
+			UInt32 id = Convert.ToUInt32(filename.Split('-')[0]);
+			Texture2D texture = new Texture2D(2, 2);
+			texture.LoadImage(File.ReadAllBytes(path));
+			textures.Add(id, texture);
+		}
+		catch (Exception)
+		{
+			Debug.Log("Loading textures, " + path + " skipped.");
+		}
+	}
+
+	public static Texture GetTexture(UInt32 texture_id)
 	{
 		if (textures.ContainsKey(texture_id)) return textures[texture_id];
 		else return textures[placeholderTextureId];

--- a/CometClient/Assets/Code/ContentManagement/TextureManager.cs
+++ b/CometClient/Assets/Code/ContentManagement/TextureManager.cs
@@ -6,8 +6,7 @@ using UnityEngine;
 
 public class TextureManager
 {
-
-	private static Dictionary<UInt32, Texture> textures = new Dictionary<UInt32, Texture>();
+	private Dictionary<UInt32, Texture> textures = new Dictionary<UInt32, Texture>();
 
 	private const UInt32 placeholderTextureId = 0;
 

--- a/CometClient/Assets/Code/Definitions/Gameplay.cs
+++ b/CometClient/Assets/Code/Definitions/Gameplay.cs
@@ -1,0 +1,13 @@
+﻿namespace def
+{
+
+	public static class Gameplay
+	{
+
+		//Entity parameters
+		public const float entityObjectHideSeconds = 0.5f;
+		public const float entityObjectRemoveSeconds = 60.0f;
+
+	}
+
+}

--- a/CometClient/Assets/Code/Definitions/Gameplay.cs
+++ b/CometClient/Assets/Code/Definitions/Gameplay.cs
@@ -5,7 +5,7 @@
 	{
 
 		//Entity parameters
-		public const float entityObjectHideSeconds = 0.5f;
+		public const float entityObjectHideSeconds = 0.1f;
 		public const float entityObjectRemoveSeconds = 60.0f;
 
 	}

--- a/CometClient/Assets/Code/Definitions/Gameplay.cs.meta
+++ b/CometClient/Assets/Code/Definitions/Gameplay.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: e3c347dcb3a6ae34ca22a4a4c56746d9
+timeCreated: 1572708765
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CometClient/Assets/Code/Definitions/Network.cs
+++ b/CometClient/Assets/Code/Definitions/Network.cs
@@ -2,7 +2,7 @@
 namespace def
 {
 
-	static class Network
+	public static class Network
 	{
 
 		//Socket parameters
@@ -19,6 +19,7 @@ namespace def
 
 		//TODO: Actually implement this behaviour.
 		public const uint my_entity_id = 0;
+
 	}
 
 }

--- a/CometClient/Assets/Code/Entities.meta
+++ b/CometClient/Assets/Code/Entities.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 7bc5a3409423f2945bfb7faf0fb274ae
+folderAsset: yes
+timeCreated: 1572708114
+licenseType: Free
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CometClient/Assets/Code/Entities/EntityController.cs
+++ b/CometClient/Assets/Code/Entities/EntityController.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+
+namespace entity
+{
+
+	public class EntityController : MonoBehaviour
+	{
+
+		private float stateLastUpdated;
+
+		private void Start()
+		{
+			stateLastUpdated = Time.time;
+		}
+
+		private void Update()
+		{
+			if (Time.time - stateLastUpdated > def.Gameplay.entityObjectHideSeconds)
+			{
+				gameObject.SetActive(false);
+			}
+			if (Time.time - stateLastUpdated > def.Gameplay.entityObjectRemoveSeconds)
+			{
+				Destroy(gameObject);
+			}
+		}
+
+		//This one is not an internal Unity function, but called explicitly.
+		public void UpdateState(float x, float y, float phi)
+		{
+			stateLastUpdated = Time.time;
+			if (!gameObject.activeInHierarchy) gameObject.SetActive(true);
+
+			gameObject.transform.rotation = Quaternion.Euler(0, 0, Mathf.Rad2Deg * phi);
+			gameObject.transform.position = new Vector3(x, y, 0);
+		}
+	}
+
+}

--- a/CometClient/Assets/Code/Entities/EntityController.cs
+++ b/CometClient/Assets/Code/Entities/EntityController.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 
 
 namespace entity

--- a/CometClient/Assets/Code/Entities/EntityController.cs.meta
+++ b/CometClient/Assets/Code/Entities/EntityController.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: a0526aad6f347fb4682e9e3f9397b548
+timeCreated: 1572708217
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CometClient/Assets/Code/Networking/BinarySerializer.cs
+++ b/CometClient/Assets/Code/Networking/BinarySerializer.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 namespace net
 {
 
-	class BinarySerializer
+	public class BinarySerializer
 	{
 
 		[StructLayout(LayoutKind.Explicit)]

--- a/CometClient/Assets/Code/Networking/NetworkController.cs
+++ b/CometClient/Assets/Code/Networking/NetworkController.cs
@@ -125,16 +125,8 @@ public class NetworkController : MonoBehaviour
 					break;
 				case net.packet_type.shape_description:
 					shape_description.Process(net.BinarySerializer.IOMode.Read, receive_buffer, bytes_read);
-					GameObject entityGameObject = new GameObject("Entity#" + shape_description.entity_id);
-					entityGameObject.AddComponent<MeshFilter>();
-					entityGameObject.AddComponent<MeshRenderer>();
-					entityGameObject.GetComponent<MeshFilter>().mesh = MeshFactory.Create(shape_description.vertex_count, shape_description.triangle_count,
-						shape_description.vertices, shape_description.uvs, shape_description.triangles);
-					//TODO: Some kind of default material should be used here, so the fisheye could be turned off if desired.
-					entityGameObject.GetComponent<MeshRenderer>().material = new Material(Resources.Load<Shader>("Fisheye"));
-					entityGameObject.GetComponent<MeshRenderer>().material.mainTexture = TextureManager.GetTexture(shape_description.texture_id);
-					Destroy(entities[shape_description.entity_id]);
-					entities[shape_description.entity_id] = entityGameObject;
+					if (entities.ContainsKey(shape_description.entity_id)) Destroy(entities[shape_description.entity_id]);
+					entities[shape_description.entity_id] = EntityFactory.Create(shape_description);
 					break;
 			}
 		}

--- a/CometClient/Assets/Code/Networking/NetworkController.cs
+++ b/CometClient/Assets/Code/Networking/NetworkController.cs
@@ -121,8 +121,7 @@ public class NetworkController : MonoBehaviour
 							udp_client.Send(send_buffer, shape_request.Process(net.BinarySerializer.IOMode.Write, send_buffer, 0));
 							entities.Add(entity.entity_id, Instantiate(placeHolder));
 						}
-						entities[entity.entity_id].transform.rotation = Quaternion.Euler(0, 0, Mathf.Rad2Deg * (float)entity.phi);
-						entities[entity.entity_id].transform.position = new Vector3((float)entity.x, (float)entity.y, 0);
+						entities[entity.entity_id].GetComponent<entity.EntityController>().UpdateState((float)entity.x, (float)entity.y, (float)entity.phi);
 					}
 					break;
 				case net.packet_type.shape_description:
@@ -133,15 +132,17 @@ public class NetworkController : MonoBehaviour
 					break;
 			}
 		}
+		
 		if (entities.ContainsKey(def.Network.my_entity_id))
 		{
 			mainCamera.transform.position =
-			new Vector3
-			(
-				entities[def.Network.my_entity_id].transform.position.x,
-				entities[def.Network.my_entity_id].transform.position.y,
-				mainCamera.transform.position.z
-			);
+				new Vector3
+				(
+					entities[def.Network.my_entity_id].transform.position.x,
+					entities[def.Network.my_entity_id].transform.position.y,
+					mainCamera.transform.position.z
+				);
+
 		}
 	}
 

--- a/CometClient/Assets/Code/Networking/NetworkController.cs
+++ b/CometClient/Assets/Code/Networking/NetworkController.cs
@@ -120,6 +120,7 @@ public class NetworkController : MonoBehaviour
 							//nor does it throw any exceptions.
 							udp_client.Send(send_buffer, shape_request.Process(net.BinarySerializer.IOMode.Write, send_buffer, 0));
 							entities.Add(entity.entity_id, Instantiate(placeHolder));
+							entities[entity.entity_id].AddComponent<entity.EntityController>();
 						}
 						entities[entity.entity_id].GetComponent<entity.EntityController>().UpdateState((float)entity.x, (float)entity.y, (float)entity.phi);
 					}
@@ -132,7 +133,7 @@ public class NetworkController : MonoBehaviour
 					break;
 			}
 		}
-		
+
 		if (entities.ContainsKey(def.Network.my_entity_id))
 		{
 			mainCamera.transform.position =

--- a/CometClient/Assets/Code/Networking/NetworkController.cs
+++ b/CometClient/Assets/Code/Networking/NetworkController.cs
@@ -22,13 +22,8 @@ public class NetworkController : MonoBehaviour
 	private UdpClient udp_client;
 	private Dictionary<UInt32, GameObject> entities = new Dictionary<UInt32, GameObject>();
 
-	private TextureManager textureManager;
-
 	private void Start()
 	{
-		//Loading textures.
-		textureManager = new TextureManager();
-
 		client_input =
 			new net.Packet<net.Header, net.ClientInputPayload>
 			{
@@ -137,7 +132,7 @@ public class NetworkController : MonoBehaviour
 						shape_description.vertices, shape_description.uvs, shape_description.triangles);
 					//TODO: Some kind of default material should be used here, so the fisheye could be turned off if desired.
 					entityGameObject.GetComponent<MeshRenderer>().material = new Material(Resources.Load<Shader>("Fisheye"));
-					entityGameObject.GetComponent<MeshRenderer>().material.mainTexture = textureManager.GetTexture(shape_description.texture_id);
+					entityGameObject.GetComponent<MeshRenderer>().material.mainTexture = TextureManager.GetTexture(shape_description.texture_id);
 					Destroy(entities[shape_description.entity_id]);
 					entities[shape_description.entity_id] = entityGameObject;
 					break;

--- a/CometClient/Assets/Code/Networking/NetworkController.cs
+++ b/CometClient/Assets/Code/Networking/NetworkController.cs
@@ -21,9 +21,11 @@ public class NetworkController : MonoBehaviour
 	private IPEndPoint server;
 	private UdpClient udp_client;
 	private Dictionary<UInt32, GameObject> entities = new Dictionary<UInt32, GameObject>();
+	private EntityFactory entityFactory;
 
 	private void Start()
 	{
+		entityFactory = new EntityFactory();
 		client_input =
 			new net.Packet<net.Header, net.ClientInputPayload>
 			{
@@ -126,17 +128,21 @@ public class NetworkController : MonoBehaviour
 				case net.packet_type.shape_description:
 					shape_description.Process(net.BinarySerializer.IOMode.Read, receive_buffer, bytes_read);
 					if (entities.ContainsKey(shape_description.entity_id)) Destroy(entities[shape_description.entity_id]);
-					entities[shape_description.entity_id] = EntityFactory.Create(shape_description);
+					entities[shape_description.entity_id] = entityFactory.Create(shape_description);
+
 					break;
 			}
 		}
-		mainCamera.transform.position =
+		if (entities.ContainsKey(def.Network.my_entity_id))
+		{
+			mainCamera.transform.position =
 			new Vector3
 			(
 				entities[def.Network.my_entity_id].transform.position.x,
 				entities[def.Network.my_entity_id].transform.position.y,
 				mainCamera.transform.position.z
 			);
+		}
 	}
 
 }

--- a/CometClient/Assets/Code/Networking/Packets.cs
+++ b/CometClient/Assets/Code/Networking/Packets.cs
@@ -11,14 +11,14 @@ namespace net
 	using entity_id = UInt32; //TODO: Find some way to emulate global typedefs.
 	using texture_id = UInt32;
 
-	enum packet_type { client_input, server_state, shape_request, shape_description };
+	public enum packet_type { client_input, server_state, shape_request, shape_description };
 
-	interface BinarySerializable
+	public interface BinarySerializable
 	{
 		int Process(net.BinarySerializer.IOMode io_mode, Byte[] packet_data, int start_index);
 	}
 
-	class Header : BinarySerializable
+	public class Header : BinarySerializable
 	{
 		public uint8_t protocol_id;
 		public uint32_t sequence_number;
@@ -34,7 +34,7 @@ namespace net
 		}
 	};
 
-	class ServerHeader : BinarySerializable
+	public class ServerHeader : BinarySerializable
 	{
 		public Header common_header;
 		public uint32_t ack;
@@ -50,7 +50,7 @@ namespace net
 		}
 	};
 
-	class ClientInputPayload : BinarySerializable
+	public class ClientInputPayload : BinarySerializable
 	{
 		public entity_id entity_id;
 		public uint8_t duration;
@@ -71,7 +71,7 @@ namespace net
 		}
 	};
 
-	class ServerObject : BinarySerializable
+	public class ServerObject : BinarySerializable
 	{
 		public entity_id entity_id; //TODO: Originally this was called 'type'. Find out why.
 		public double phi;
@@ -89,7 +89,7 @@ namespace net
 		}
 	};
 
-	class ServerStatePayload : BinarySerializable
+	public class ServerStatePayload : BinarySerializable
 	{
 		public uint16_t count;
 		public ServerObject[] objects;
@@ -106,7 +106,7 @@ namespace net
 		}
 	};
 
-	class ShapeRequest : BinarySerializable
+	public class ShapeRequest : BinarySerializable
 	{
 		public entity_id entity_id;
 
@@ -118,7 +118,7 @@ namespace net
 		}
 	};
 
-	class ShapeDescription : BinarySerializable
+	public class ShapeDescription : BinarySerializable
 	{
 		public entity_id entity_id;
 		public texture_id texture_id;
@@ -151,7 +151,7 @@ namespace net
 		}
 	};
 
-	class Packet<H, P> where H : BinarySerializable where P : BinarySerializable
+	public class Packet<H, P> where H : BinarySerializable where P : BinarySerializable
 	{
 		public H header;
 		public P payload;

--- a/CometClient/CometClient.csproj
+++ b/CometClient/CometClient.csproj
@@ -287,7 +287,9 @@
     <Compile Include="Assets\Code\ContentManagement\EntityFactory.cs" />
     <Compile Include="Assets\Code\ContentManagement\MeshFactory.cs" />
     <Compile Include="Assets\Code\ContentManagement\TextureManager.cs" />
+    <Compile Include="Assets\Code\Definitions\Gameplay.cs" />
     <Compile Include="Assets\Code\Definitions\Network.cs" />
+    <Compile Include="Assets\Code\Entities\EntityController.cs" />
     <Compile Include="Assets\Code\Networking\BinarySerializer.cs" />
     <Compile Include="Assets\Code\Networking\NetworkController.cs" />
     <Compile Include="Assets\Code\Networking\Packets.cs" />

--- a/CometClient/CometClient.csproj
+++ b/CometClient/CometClient.csproj
@@ -284,6 +284,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Assets\Code\Camera\FisheyeCameraController.cs" />
+    <Compile Include="Assets\Code\ContentManagement\EntityFactory.cs" />
     <Compile Include="Assets\Code\ContentManagement\MeshFactory.cs" />
     <Compile Include="Assets\Code\ContentManagement\TextureManager.cs" />
     <Compile Include="Assets\Code\Definitions\Network.cs" />


### PR DESCRIPTION
This PR introduces `EntityFactory` to manage entity creation, and `EntityController`, to encapsulate position and other state updates of entities.
I made almost everything non-static, because the initialization of `TextureManager` (reading in texture files) seem to have quite a big performance overhead if done in a `static` (actually it probably takes the same amount of time, but it happens at a totally unexpected and annoying time).
Also made every class explcitily public if it wasn't aleady.
Pay special attention to the part
```
entities.Add(entity.entity_id, Instantiate(placeHolder));
entities[entity.entity_id].AddComponent<entity.EntityController>();
```
Placeholder entities also have to have their own `EntityController`, otherwise the `GetComponent` calls return `nulls`, accessing those naturally cause `NullReferenceException`s (and consequently lag spikes), and to make things worse, for whatever reason Unity seems to swallow exceptions, so it's pretty hard to track down. Further details here: https://www.reddit.com/r/Unity2D/comments/egda2u/unity_swallowing_exceptions/
