### PR TITLE
Add fail-fast: false in vscpp.yml

### DIFF
--- a/.github/workflows/vscpp.yml
+++ b/.github/workflows/vscpp.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: windows-latest
     
     strategy:
+      fail-fast: false
       matrix:
         configuration: [Debug, Release]
         platform: [Win32, x64]


### PR DESCRIPTION
This is useful, because with the default true setting if one job crashes then all the other ones are cancelled, too.