### PR TITLE
Use windows-2019 instead of windows-latest in vscpp.yml

### DIFF
--- a/.github/workflows/vscpp.yml
+++ b/.github/workflows/vscpp.yml
@@ -13,7 +13,7 @@ jobs:
     
     name: Build and test server
 
-    runs-on: windows-latest
+    runs-on: windows-2019
     
     strategy:
       fail-fast: false


### PR DESCRIPTION
In github workflow `windows-latest` now defaults to Windows Server 2022 (see here: https://github.com/actions/virtual-environments/issues/4856). We want to stick to 2019 for now, so we had to specify the version explicitly. Otherwise workflows just fail.